### PR TITLE
[feat] : 관리자 유저 수영 기록 조회 구현 및 Query DTO 문제 해결

### DIFF
--- a/src/common/middleware/auth.middleware.ts
+++ b/src/common/middleware/auth.middleware.ts
@@ -53,8 +53,9 @@ export class AuthMiddleware implements NestMiddleware {
         maxAge : 5 * 60 * 1000, // 5 분
       });
 
-      // 새로 생성된 access 토큰으로 컨트롤러에 넘겨줄 "user" 속성 정의
-      req["user"] = await this.authService.validateAccessToken(accessToken);
+      // 아주 가끔씩 JS 엔진의 동기적 운용으로 인해 req["user"] 가 할당되기 전에, 컨트롤러 핸들러 메서드에서 먼저 req["user"] 를 조회하는 일이 발생.
+      // 따라서, 이미 값이 존재하는 리프레쉬 토큰으로 바로 할당. - 어짜피 refresh 가 만료되지 않았다는 것은, 인증된 사용자라는 의미 (access < refresh)
+      req["user"] = tokenPayload;
 
       // access, refresh 두 토큰 모두 살아 있는 상황.
     } else {

--- a/src/pools/pools.module.ts
+++ b/src/pools/pools.module.ts
@@ -31,7 +31,7 @@ import { BookmarksModule } from '../bookmarks/bookmarks.module';
   exports: [PoolsService, CoordinateApiService, TypeOrmModule, ]
 })
 export class PoolsModule implements NestModule {
-  configure(consumer: MiddlewareConsumer) {
+  async configure(consumer: MiddlewareConsumer) {
     consumer
       .apply(AuthMiddleware)
       .exclude(

--- a/src/swim_logs/dto/adminSearchSwimLogs.dto.ts
+++ b/src/swim_logs/dto/adminSearchSwimLogs.dto.ts
@@ -1,9 +1,8 @@
-import { IsInt, IsNotEmpty, IsNumber, IsOptional } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
+import { IsInt, IsNotEmpty, IsOptional, IsString } from "class-validator";
 import { Type } from "class-transformer";
 
-// 연도(4자리) 와 월(1~12) 는 필수. 그리고 날짜는 선택(1 ~ 31)
-export class SwimLogQueryDto {
+export class AdminSearchSwimLogsDto {
   @ApiProperty()
   @IsNotEmpty()
   @IsInt()
@@ -11,7 +10,7 @@ export class SwimLogQueryDto {
   year : number;
 
   @ApiProperty()
-  @IsNotEmpty()
+  @IsOptional()
   @IsInt()
   @Type(() => Number)
   month : number;

--- a/src/swim_logs/swim_logs.module.ts
+++ b/src/swim_logs/swim_logs.module.ts
@@ -13,7 +13,7 @@ import { AuthMiddleware } from "../common/middleware/auth.middleware";
   exports: [SwimLogsService, TypeOrmModule],
 })
 export class SwimLogsModule implements NestModule {
-  configure(consumer: MiddlewareConsumer) {
+  async configure(consumer: MiddlewareConsumer) {
     consumer
       .apply(AuthMiddleware)
       .forRoutes(SwimLogsController)

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -17,7 +17,7 @@ import { AuthService } from "../auth/auth.service";
   exports: [TypeOrmModule, UsersService],
 })
 export class UsersModule implements NestModule {
-  configure(consumer: MiddlewareConsumer) {
+  async configure(consumer: MiddlewareConsumer) {
     consumer
       // 쿠키 기반의 인증 적용
       .apply(AuthMiddleware)


### PR DESCRIPTION
<!-- 작업 주제 or 제목을 적어주세요 --> 
## Pull Request 작업

- [x] API 생성
- [x] 버그 수정
- [x] 리팩토링


<br/>

<!-- 설명을 적어주세요 -->
## 설명

관리자는 쿼리로 입력한 기간 동안의 유저 수영 기록을 관측할 수 있으며,

해당 기간에 몇 명의 유저가 수영을 기록했는지,

그리고 수영 한 길이의 총량을 알 수 있다 (모든 유저)

<br/> 

<!-- 한 일이 무엇인지 자세히 알려주세요 -->
## TODO

- [x] `AuthModule` 에서 액세스 토큰 만료 시, 리프레쉬 토큰으로 핸들러에게 JWT 페이로드 제공
- [x] `GET api/v1/logs/user-logs` 관리자 유저 수영 기록 조회 API 구현
- [x] Query DTO 수정 