### PR TITLE
[fix] : NODE_ENV 개발 환경 시, localhost:3306 을 참조하도록 변경

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,7 +27,7 @@ import { UserImages } from "./users/user-images.entity";
     ConfigModule.forRoot({isGlobal : true}),
     TypeOrmModule.forRoot({
       type: process.env.DB_TYPE as "mysql",
-      host: process.env.DB_HOST,
+      host: process.env.NODE_ENV === "development" ? "localhost:3306" : process.env.DB_HOST,
       port: parseInt(process.env.DB_PORT),
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,


### PR DESCRIPTION
<!-- 작업 주제 or 제목을 적어주세요 --> 
## Pull Request 작업

- [ ] API 생성
- [ ] 버그 수정
- [x] 리팩토링


<br/>

<!-- 설명을 적어주세요 -->
## 설명

개발 환경과 프로덕션 환경에서 다른 DB_HOST 를 참조하도록 변경 

(현재 RDS 종료했기 때문)


<br/> 

<!-- 한 일이 무엇인지 자세히 알려주세요 -->
## TODO

- [x] 처음 TypeORM2 설정 시, `DB_HOST` 는 개발과 프로덕션에서 다른 호스트를 참조하도록 변경.
